### PR TITLE
fix google login (get_user_info)

### DIFF
--- a/models/openid/google.php
+++ b/models/openid/google.php
@@ -154,10 +154,8 @@ class openid_google_class extends AWS_MODEL
 
             return false;
         }
-
-        $header = array('Authorization: Bearer ' . $this->access_token);
-
-        $result = HTTP::request(self::OAUTH2_USER_INFO_URL, 'GET', null, 10, $header);
+        
+        $result = curl_get_contents(self::OAUTH2_USER_INFO_URL . '?alt=json&access_token=' . $this->access_token);
 
         if (!$result)
         {


### PR DESCRIPTION
get_user_info function 中对/oauth2/v2/userinfo 的调用改成了GET ?alt=json&access_token=YourToken, 原方式似乎已失效