### PR TITLE
修复验证码漏洞

### DIFF
--- a/system/core/captcha.php
+++ b/system/core/captcha.php
@@ -72,7 +72,7 @@ class core_captcha
 
 	public function is_validate($validate_code, $generate_new = true)
 	{
-		if (strtolower($this->captcha->getWord()) == strtolower($validate_code))
+		if (!empty($validate) AND strtolower($this->captcha->getWord()) == strtolower($validate_code))
 		{
 			if ($generate_new)
 			{


### PR DESCRIPTION
当注册机不提交seccode_verify或seccode_verify=''时可通过验证造成恶意注册