### PR TITLE
修复传参时的逻辑问题

### DIFF
--- a/models/topic.php
+++ b/models/topic.php
@@ -597,7 +597,7 @@ class topic_class extends AWS_MODEL
 	{
 		return $this->get_item_ids_by_topics_ids(array(
 			$topic_id
-		), $limit);
+		), $type, $limit);
 	}
 
 	public function get_item_ids_by_topics_ids($topic_ids, $type = null, $limit = null)


### PR DESCRIPTION
当向get_item_ids_by_topics_id传入三个参数时会导致返回内容为空