### PR TITLE
在windows下换行符是\r\n，如果git的auto.crlf=true的话那么sql的换行符就是\r\n，这样读入的sql语句就有\…

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -386,6 +386,8 @@ switch ($_POST['step'])
 
 		foreach ($insert_query AS $_sql)
 		{
+			if(empty($_sql))
+				continue;
 			$insert_vars = explode("', '", ltrim(rtrim(rtrim(rtrim($_sql, ','), ';'), ')'), '('));
 						
 			try {


### PR DESCRIPTION
…r\n，把\n替换成\r就是\r\r，这样explode以后会有空的字符串，插入的时候就出错