### PR TITLE
正文与附件关联关系丢失

### DIFF
--- a/app/publish/ajax.php
+++ b/app/publish/ajax.php
@@ -689,6 +689,7 @@ class ajax extends AWS_CONTROLLER
                 'message' => $_POST['message'],
                 'category_id' => $_POST['category_id'],
                 'topics' => $_POST['topics'],
+                'attach_access_key' => $_POST['attach_access_key'],
                 'permission_create_topic' => $this->user_info['permission']['create_topic']
             ), $this->user_id, $_POST['attach_access_key']);
 


### PR DESCRIPTION
修复发表文章到审核池后，丢失了正文与附件关联关系的bug。associates between article and attaches missed while publish article to approval pool