### PR TITLE
修改url有项目名称的情况下，后台登录后地址跳转错误（丢失项目名）

### DIFF
--- a/app/admin/ajax.php
+++ b/app/admin/ajax.php
@@ -55,8 +55,10 @@ class ajax extends AWS_ADMIN_CONTROLLER
         {
             $this->model('admin')->set_admin_login($user_info['uid']);
 
+            $url=$_POST['url'] ? base64_decode($_POST['url']) : '/admin/';
+            
             H::ajax_json_output(AWS_APP::RSM(array(
-                'url' => $_POST['url'] ? base64_decode($_POST['url']) : get_js_url('/admin/')
+                'url' => get_js_url($url)
             ), 1, null));
         }
         else

--- a/app/admin/ajax.php
+++ b/app/admin/ajax.php
@@ -55,7 +55,7 @@ class ajax extends AWS_ADMIN_CONTROLLER
         {
             $this->model('admin')->set_admin_login($user_info['uid']);
 
-            $url=$_POST['url'] ? base64_decode($_POST['url']) : '/admin/';
+            $url = $_POST['url'] ? base64_decode($_POST['url']) : '/admin/';
             
             H::ajax_json_output(AWS_APP::RSM(array(
                 'url' => get_js_url($url)


### PR DESCRIPTION
例如：访问地址www.wecenter.com/wecenter/
后台登录跳转到了www.wecenter.com/admin(丢失了wecenter)