### PR TITLE
php7 disallow count string

### DIFF
--- a/system/Zend/Db/Table/Abstract.php
+++ b/system/Zend/Db/Table/Abstract.php
@@ -1304,13 +1304,16 @@ abstract class Zend_Db_Table_Abstract
         $whereList = array();
         $numberTerms = 0;
         foreach ($args as $keyPosition => $keyValues) {
-            $keyValuesCount = count($keyValues);
+            //php7 disallow count string
+            //$keyValuesCount = count($keyValues);
             // Coerce the values to an array.
             // Don't simply typecast to array, because the values
             // might be Zend_Db_Expr objects.
             if (!is_array($keyValues)) {
                 $keyValues = array($keyValues);
             }
+            //php7 disallow count string
+            $keyValuesCount = count($keyValues);
             if ($numberTerms == 0) {
                 $numberTerms = $keyValuesCount;
             } else if ($keyValuesCount != $numberTerms) {


### PR DESCRIPTION
php7.2不允许count string。

另外由于Mcrypt再7.2被废弃所以我找到了这个：`https://github.com/phpseclib/mcrypt_compat`，试了一下可以不装Mcrypt。但是这个又依赖了composer下的phpseclib库，而wecenter又没有使用composer，我在想怎么提PR集成过去比较好